### PR TITLE
Dispatch WPF UI updates asynchronously instead of synchronously

### DIFF
--- a/Mapsui.UI.Xaml/MapControl.cs
+++ b/Mapsui.UI.Xaml/MapControl.cs
@@ -226,7 +226,7 @@ namespace Mapsui.UI.Xaml
         private void RefreshGraphics()
         {
 #if (!SILVERLIGHT && !WINDOWS_PHONE)
-            Dispatcher.Invoke(new Action(() =>
+            Dispatcher.BeginInvoke(new Action(() =>
             {
 
                 InvalidateVisual();


### PR DESCRIPTION
I had a custom ITileSource in which I was retrieving tiles from the local file system instead of remote HTTP requests. I was getting StackOverflowExceptions when the map data was updated until I dispatched UI updates asynchronously.