### PR TITLE
WMS bugfix: parsing error occurred when Capabilities did not containe…

### DIFF
--- a/Mapsui.Desktop/Wms/Client.cs
+++ b/Mapsui.Desktop/Wms/Client.cs
@@ -434,6 +434,9 @@ namespace Mapsui.Web.Wms
             ParseGetMapRequest(xnGetMap);
 
             XmlNode xnGetFeatureInfo = xmlRequestNode.SelectSingleNode("sm:GetFeatureInfo", nsmgr);
+            if (xnGetFeatureInfo == null)
+                return;
+
             ParseGetFeatureInfo(xnGetFeatureInfo);
         }
 


### PR DESCRIPTION
WMS bugfix: parsing error occurred when Capabilities did not contained (the optional) GetfeatureInfo section