### PR TITLE
Resolved issue #31 - Rotation in Xaml Renderer should be working fine now.

### DIFF
--- a/Mapsui.Rendering.Xaml/GeometryRenderer.cs
+++ b/Mapsui.Rendering.Xaml/GeometryRenderer.cs
@@ -116,16 +116,16 @@ namespace Mapsui.Rendering.Xaml
             var pointOffsetFromViewPortCenterX = point.X - viewport.Center.X;
             var pointOffsetFromViewPortCenterY = point.Y - viewport.Center.Y;
 
-            matrix.Translate(pointOffsetFromViewPortCenterX, pointOffsetFromViewPortCenterY);
+            MatrixHelper.Translate(ref matrix, pointOffsetFromViewPortCenterX, pointOffsetFromViewPortCenterY);
 
             if (viewport.IsRotated)
             {
-                matrix.Rotate(-viewport.Rotation);
+                MatrixHelper.Rotate(ref matrix, -viewport.Rotation);
             }
 
 
-            matrix.Translate(mapCenterX, mapCenterY);
-            matrix.ScaleAt(1 / viewport.Resolution, 1 / viewport.Resolution, mapCenterX, mapCenterY);
+            MatrixHelper.Translate(ref matrix, mapCenterX, mapCenterY);
+            MatrixHelper.ScaleAt(ref matrix, 1 / viewport.Resolution, 1 / viewport.Resolution, mapCenterX, mapCenterY);
 
             // This will invert the Y axis, but will also put images upside down
             MatrixHelper.InvertY(ref matrix, mapCenterY);

--- a/Mapsui.Rendering.Xaml/GeometryRenderer.cs
+++ b/Mapsui.Rendering.Xaml/GeometryRenderer.cs
@@ -110,16 +110,22 @@ namespace Mapsui.Rendering.Xaml
         private static XamlMedia.Matrix CreateTransformMatrix(Point point, IViewport viewport)
         {
             var matrix = XamlMedia.Matrix.Identity;
-            MatrixHelper.Translate(ref matrix, point.X, point.Y);
             var mapCenterX = viewport.Width * 0.5;
             var mapCenterY = viewport.Height * 0.5;
+            
+            var pointOffsetFromViewPortCenterX = point.X - viewport.Center.X;
+            var pointOffsetFromViewPortCenterY = point.Y - viewport.Center.Y;
 
-            MatrixHelper.Translate(ref matrix, mapCenterX - viewport.Center.X, mapCenterY - viewport.Center.Y);
+            matrix.Translate(pointOffsetFromViewPortCenterX, pointOffsetFromViewPortCenterY);
+
             if (viewport.IsRotated)
             {
-                MatrixHelper.RotateAt(ref matrix, -viewport.Rotation);
+                matrix.Rotate(-viewport.Rotation);
             }
-            MatrixHelper.ScaleAt(ref matrix, 1 / viewport.Resolution, 1 / viewport.Resolution, mapCenterX, mapCenterY);
+
+
+            matrix.Translate(mapCenterX, mapCenterY);
+            matrix.ScaleAt(1 / viewport.Resolution, 1 / viewport.Resolution, mapCenterX, mapCenterY);
 
             // This will invert the Y axis, but will also put images upside down
             MatrixHelper.InvertY(ref matrix, mapCenterY);
@@ -132,12 +138,12 @@ namespace Mapsui.Rendering.Xaml
             var mapCenterX = viewport.Width * 0.5;
             var mapCenterY = viewport.Height * 0.5;
 
-            MatrixHelper.Translate(ref matrix, mapCenterX - viewport.Center.X, mapCenterY - viewport.Center.Y);
+            matrix.Translate(mapCenterX - viewport.Center.X, mapCenterY - viewport.Center.Y);
             if (viewport.IsRotated)
             {
-                MatrixHelper.RotateAt(ref matrix, -viewport.Rotation);
+                matrix.Rotate(-viewport.Rotation);
             }
-            MatrixHelper.ScaleAt(ref matrix, 1 / viewport.Resolution, 1 / viewport.Resolution, mapCenterX, mapCenterY);
+            matrix.ScaleAt(1 / viewport.Resolution, 1 / viewport.Resolution, mapCenterX, mapCenterY);
 
             // This will invert the Y axis, but will also put images upside down
             MatrixHelper.InvertY(ref matrix, mapCenterY);

--- a/Mapsui.Rendering.Xaml/GeometryRenderer.cs
+++ b/Mapsui.Rendering.Xaml/GeometryRenderer.cs
@@ -134,20 +134,7 @@ namespace Mapsui.Rendering.Xaml
 
         private static XamlMedia.Matrix CreateTransformMatrix1(IViewport viewport)
         {
-            var matrix = XamlMedia.Matrix.Identity;
-            var mapCenterX = viewport.Width * 0.5;
-            var mapCenterY = viewport.Height * 0.5;
-
-            matrix.Translate(mapCenterX - viewport.Center.X, mapCenterY - viewport.Center.Y);
-            if (viewport.IsRotated)
-            {
-                matrix.Rotate(-viewport.Rotation);
-            }
-            matrix.ScaleAt(1 / viewport.Resolution, 1 / viewport.Resolution, mapCenterX, mapCenterY);
-
-            // This will invert the Y axis, but will also put images upside down
-            MatrixHelper.InvertY(ref matrix, mapCenterY);
-            return matrix;
+            return CreateTransformMatrix(new Point(0, 0), viewport);
         }
 
         private static XamlShapes.Shape CreateSymbolFromBitmap(Stream data, double opacity)


### PR DESCRIPTION
Fixed transformation stacking bug, causing displacement of rotated symbols.