### PR TITLE
Change BackColor, so that RefreshGraphics is called

### DIFF
--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -37,6 +37,7 @@ namespace Mapsui
     {
         private LayerCollection _layers = new LayerCollection();
         private bool _lock;
+		private Color _backColor;
 
         /// <summary>
         /// Initializes a new map
@@ -137,7 +138,17 @@ namespace Mapsui
         /// <summary>
         /// Map background color (defaults to transparent)
         ///  </summary>
-        public Color BackColor { get; set; } 
+        public Color BackColor
+		{
+			get { return _backColor; }
+			set
+			{
+				if (_backColor == value)
+					return;
+				_backColor = value;
+				OnRefreshGraphics();
+			}
+		} 
 
         /// <summary>
         /// Gets the extents of the map based on the extents of all the layers in the layers collection

--- a/Mapsui/Map.cs
+++ b/Mapsui/Map.cs
@@ -37,7 +37,7 @@ namespace Mapsui
     {
         private LayerCollection _layers = new LayerCollection();
         private bool _lock;
-		private Color _backColor;
+		private Color _backColor = Color.White;
 
         /// <summary>
         /// Initializes a new map


### PR DESCRIPTION
If you change BackColor of Map, than the map isn't refreshed. This is perhaps a bug.

PS: Sorry, see while creating PR that the idents are not correct. How much ident do you use? And how many spaces are one tab?