### PR TITLE
Hotfix/issue206

### DIFF
--- a/Mapsui.Rendering.Skia-PCL/LabelRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/LabelRenderer.cs
@@ -88,6 +88,23 @@ namespace Mapsui.Rendering.Skia
             backRect.Inflate(3, 3);
             DrawBackground(style, backRect, target);
 
+            if (style.Halo != null)
+            {
+                var haloPaint = CreatePaint(style);
+                haloPaint.Style = SKPaintStyle.StrokeAndFill;
+                haloPaint.Color = style.Halo.Color.ToSkia();
+
+                // TODO: PenStyle
+                /*
+                float[] intervals = { 10.0f, 5.0f, 2.0f, 5.0f };
+                haloPaint.SetPathEffect(SkDashPathEffect::Make(intervals, count, 0.0f));
+                */
+
+                haloPaint.StrokeWidth = (float)style.Halo.Width * 2;
+
+                target.DrawText(text, rect.Left, rect.Bottom, haloPaint);
+            }
+
             target.DrawText(text, rect.Left, rect.Bottom, paint);
         }
 

--- a/Mapsui.Rendering.Xaml/SingleLabelRenderer.cs
+++ b/Mapsui.Rendering.Xaml/SingleLabelRenderer.cs
@@ -24,8 +24,19 @@ namespace Mapsui.Rendering.Xaml
                 Foreground = new SolidColorBrush(labelStyle.ForeColor.ToXaml()),
                 FontFamily = new FontFamily(labelStyle.Font.FontFamily),
                 FontSize = labelStyle.Font.Size,
-                Margin = new Thickness(witdhMargin, heightMargin, witdhMargin, heightMargin)
+                Margin = new Thickness(witdhMargin, heightMargin, witdhMargin, heightMargin),
             };
+
+            // TODO: Halo is not supported by WPF, but we CAN do an outer glow-like effect...
+            if (labelStyle.Halo != null)
+            {
+                System.Windows.Media.Effects.DropShadowEffect haloEffect = new System.Windows.Media.Effects.DropShadowEffect();
+                haloEffect.ShadowDepth = 0;
+                haloEffect.Color = labelStyle.Halo.Color.ToXaml();
+                haloEffect.Opacity = haloEffect.Color.A / 255.0;
+                haloEffect.BlurRadius = labelStyle.Halo.Width * 2;
+                textblock.Effect = haloEffect;
+            }
 
             var border = new Border
             {

--- a/Mapsui.UI.Uwp/MapControl.cs
+++ b/Mapsui.UI.Uwp/MapControl.cs
@@ -290,7 +290,9 @@ namespace Mapsui.UI.Uwp
             _zoomAnimation.EasingFunction = new QuarticEase();
             Storyboard.SetTarget(_zoomAnimation, this);
             Storyboard.SetTargetProperty(_zoomAnimation, nameof(Map.Viewport.Resolution));
-            _zoomStoryBoard.Children.Add(_zoomAnimation);
+
+            if (!_zoomStoryBoard.Children.Contains(_zoomAnimation))
+                _zoomStoryBoard.Children.Add(_zoomAnimation);
         }
 
         private void MapControlSizeChanged(object sender, SizeChangedEventArgs e)


### PR DESCRIPTION
This if a fix for Issue #206 in Skia, and a partial fix for #206 in WPF.

WPF doesn't have a halo capability built-in, so instead, the text has an outer glow effect to it.