### PR TITLE
Hotfix/issue209

### DIFF
--- a/Mapsui.Rendering.Skia-PCL/LabelRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/LabelRenderer.cs
@@ -88,6 +88,23 @@ namespace Mapsui.Rendering.Skia
             backRect.Inflate(3, 3);
             DrawBackground(style, backRect, target);
 
+            if (style.Halo != null)
+            {
+                var haloPaint = CreatePaint(style);
+                haloPaint.Style = SKPaintStyle.StrokeAndFill;
+                haloPaint.Color = style.Halo.Color.ToSkia();
+
+                // TODO: PenStyle
+                /*
+                float[] intervals = { 10.0f, 5.0f, 2.0f, 5.0f };
+                haloPaint.SetPathEffect(SkDashPathEffect::Make(intervals, count, 0.0f));
+                */
+
+                haloPaint.StrokeWidth = (float)style.Halo.Width * 2;
+
+                target.DrawText(text, rect.Left, rect.Bottom, haloPaint);
+            }
+
             target.DrawText(text, rect.Left, rect.Bottom, paint);
         }
 

--- a/Mapsui.Rendering.Skia-PCL/LabelRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/LabelRenderer.cs
@@ -75,15 +75,17 @@ namespace Mapsui.Rendering.Skia
             var horizontalAlign = CalcHorizontalAlignment(style.HorizontalAlignment);
             var verticalAlign = CalcVerticalAlignment(style.VerticalAlignment);
                         
+            /* This actually produces invalid values. We only want width/height.
             var backRectXOffset = -rect.Left;
             var backRectYOffset = rect.Bottom;
+            */
 
             rect.Offset(
                 x - rect.Width * horizontalAlign + (float)style.Offset.X,
                 y + rect.Height * verticalAlign + (float)style.Offset.Y);
 
             var backRect = rect; // copy
-            rect.Offset(-backRectXOffset, -backRectYOffset); // correct for text specific offset returned paint.Measure
+//            rect.Offset(-backRectXOffset, -backRectYOffset); // correct for text specific offset returned paint.Measure
 
             backRect.Inflate(3, 3);
             DrawBackground(style, backRect, target);

--- a/Mapsui.Rendering.Xaml/SingleLabelRenderer.cs
+++ b/Mapsui.Rendering.Xaml/SingleLabelRenderer.cs
@@ -24,8 +24,19 @@ namespace Mapsui.Rendering.Xaml
                 Foreground = new SolidColorBrush(labelStyle.ForeColor.ToXaml()),
                 FontFamily = new FontFamily(labelStyle.Font.FontFamily),
                 FontSize = labelStyle.Font.Size,
-                Margin = new Thickness(witdhMargin, heightMargin, witdhMargin, heightMargin)
+                Margin = new Thickness(witdhMargin, heightMargin, witdhMargin, heightMargin),
             };
+
+            // TODO: Halo is not supported by WPF, but we CAN do an outer glow-like effect...
+            if (labelStyle.Halo != null)
+            {
+                System.Windows.Media.Effects.DropShadowEffect haloEffect = new System.Windows.Media.Effects.DropShadowEffect();
+                haloEffect.ShadowDepth = 0;
+                haloEffect.Color = labelStyle.Halo.Color.ToXaml();
+                haloEffect.Opacity = haloEffect.Color.A / 255.0;
+                haloEffect.BlurRadius = labelStyle.Halo.Width * 2;
+                textblock.Effect = haloEffect;
+            }
 
             var border = new Border
             {

--- a/Mapsui.UI.Uwp/MapControl.cs
+++ b/Mapsui.UI.Uwp/MapControl.cs
@@ -290,7 +290,9 @@ namespace Mapsui.UI.Uwp
             _zoomAnimation.EasingFunction = new QuarticEase();
             Storyboard.SetTarget(_zoomAnimation, this);
             Storyboard.SetTargetProperty(_zoomAnimation, nameof(Map.Viewport.Resolution));
-            _zoomStoryBoard.Children.Add(_zoomAnimation);
+
+            if (!_zoomStoryBoard.Children.Contains(_zoomAnimation))
+                _zoomStoryBoard.Children.Add(_zoomAnimation);
         }
 
         private void MapControlSizeChanged(object sender, SizeChangedEventArgs e)


### PR DESCRIPTION
Ignores the Left/Bottom attributes from SKPaint.MeasureText. These were generating invalid values for the purpose of how the labels get renderered. It fixed my test strings, and the existing strings appear to be unaffected.