### PR TITLE
Skia renderer rotation & iOS rotation control

### DIFF
--- a/Mapsui.Rendering.Skia-PCL/RasterRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/RasterRenderer.cs
@@ -10,48 +10,74 @@ namespace Mapsui.Rendering.Skia
 {
     public static class RasterRenderer
     {
-        public static void Draw(SKCanvas canvas, IViewport viewport, IStyle style, IFeature feature,
-            IDictionary<object, BitmapInfo> tileCache, long currentIteration)
-        {
-            try
-            {
-                var raster = (IRaster)feature.Geometry;
+		public static void Draw (SKCanvas canvas, IViewport viewport, IStyle style, IFeature feature,
+			IDictionary<object, BitmapInfo> tileCache, long currentIteration)
+		{
+			try
+			{
+				var raster = (IRaster)feature.Geometry;
 
-                BitmapInfo bitmapInfo;
+				BitmapInfo bitmapInfo;
 
-                if (!tileCache.Keys.Contains(raster))
-                {
-                    bitmapInfo = BitmapHelper.LoadBitmap(raster.Data);
-                    tileCache[raster] = bitmapInfo;
-                }
-                else
-                {
-                    bitmapInfo = tileCache[raster];
-                }
+				if (!tileCache.Keys.Contains (raster))
+				{
+					bitmapInfo = BitmapHelper.LoadBitmap (raster.Data);
+					tileCache [raster] = bitmapInfo;
+				}
+				else
+				{
+					bitmapInfo = tileCache [raster];
+				}
 
-                bitmapInfo.IterationUsed = currentIteration;
-                tileCache[raster] = bitmapInfo;
-                var destination = WorldToScreen(viewport, feature.Geometry.GetBoundingBox());
-                BitmapHelper.RenderRaster(canvas, bitmapInfo.Bitmap, RoundToPixel(destination).ToSkia());
-            }
-            catch (Exception ex)
-            {
-                Logger.Log(LogLevel.Error, ex.Message, ex);
-            }
-        }
+				bitmapInfo.IterationUsed = currentIteration;
+				tileCache [raster] = bitmapInfo;
 
-        private static BoundingBox WorldToScreen(IViewport viewport, BoundingBox boundingBox)
-        {
-            var first = viewport.WorldToScreen(boundingBox.Min);
-            var second = viewport.WorldToScreen(boundingBox.Max);
-            return new BoundingBox
-            (
-                Math.Min(first.X, second.X),
-                Math.Min(first.Y, second.Y),
-                Math.Max(first.X, second.X),
-                Math.Max(first.Y, second.Y)
-            );
-        }
+				var boundingBox = feature.Geometry.GetBoundingBox ();
+
+				var priorMatrix = canvas.TotalMatrix;
+
+				SKMatrix matrix;
+
+				{
+					//The front-end sets up the canvas with a matrix based on screen scaling (e.g. retina).
+					//We need to retain that effect by combining our matrix with the incoming matrix.
+
+					//We'll create four matrices in addition to the incoming matrix. They perform the
+					//zoom scale, focal point offset, user rotation and finally, centering in the screen.
+
+					var userRotation = SKMatrix.MakeRotationDegrees ((float)viewport.Rotation);
+					var focalPointOffset = SKMatrix.MakeTranslation (
+						(float)(boundingBox.Left - viewport.Center.X),
+						(float)(viewport.Center.Y - boundingBox.Top));
+					var zoomScale = SKMatrix.MakeScale ((float)(1.0 / viewport.Resolution), (float)(1.0 / viewport.Resolution));
+					var centerInScreen = SKMatrix.MakeTranslation ((float)(viewport.Width / 2.0), (float)(viewport.Height / 2.0));
+
+					//We'll concatenate them like so: incomingMatrix * centerInScreen * userRotation * zoomScale * focalPointOffset
+
+					var bufferOne = new SKMatrix ();
+					var bufferTwo = new SKMatrix ();
+
+					SKMatrix.Concat (ref bufferOne, zoomScale, focalPointOffset);
+					SKMatrix.Concat (ref bufferTwo, userRotation, bufferOne);
+					SKMatrix.Concat (ref bufferOne, centerInScreen, bufferTwo);
+					SKMatrix.Concat (ref bufferTwo, priorMatrix, bufferOne);
+
+					matrix = bufferTwo;
+				}
+
+				canvas.SetMatrix (matrix);
+
+				var destination = new BoundingBox (0.0, 0.0, boundingBox.Width, boundingBox.Height);
+
+				BitmapHelper.RenderRaster (canvas, bitmapInfo.Bitmap, RoundToPixel (destination).ToSkia ());
+
+				canvas.SetMatrix (priorMatrix);
+			}
+			catch (Exception ex)
+			{
+				Logger.Log (LogLevel.Error, ex.Message, ex);
+			}
+		}
 
         private static BoundingBox RoundToPixel(BoundingBox boundingBox)
         {

--- a/Mapsui.UI.iOS/MapControl.cs
+++ b/Mapsui.UI.iOS/MapControl.cs
@@ -24,6 +24,7 @@ namespace Mapsui.UI.iOS
         private nfloat _previousX;
         private nfloat _previousY;
         private double _previousRadius;
+		private double _previousRotation;
 
         private float Width => (float)Frame.Width;
         private float Height => (float)Frame.Height;
@@ -162,17 +163,21 @@ namespace Mapsui.UI.iOS
 
                 centerX = centerX / touches.Count;
                 centerY = centerY / touches.Count;
+
                 var radius = Algorithms.Distance(centerX, centerY, locations[0].X, locations[0].Y);
+				var rotation = Math.Atan2 (locations [1].Y - locations [0].Y, locations [1].X - locations [0].X) * 180.0 / Math.PI;
 
                 if (_previousTouchCount == touches.Count)
                 {
                     _map.Viewport.Transform(centerX, centerY, _previousX, _previousY, radius / _previousRadius);
+					_map.Viewport.Rotation += rotation - _previousRotation;
                     RefreshGraphics();
                 }
 
                 _previousX = centerX;
                 _previousY = centerY;
                 _previousRadius = radius;
+				_previousRotation = rotation;
             }
             _previousTouchCount = touches.Count;
         }


### PR DESCRIPTION
I'm using a matrix to control the positioning of tiles.

This is the only way to do this but unfortunately means the world-to-screen algorithm is implemented twice; once in the viewport and again in the Skia raster renderer.

If one is changed, the other will have to be changed to match.