### PR TITLE
Fix NullException ocurring in GetFeaturesInView() when BoundingBox is null

### DIFF
--- a/Mapsui/Layers/MemoryLayer.cs
+++ b/Mapsui/Layers/MemoryLayer.cs
@@ -13,6 +13,9 @@ namespace Mapsui.Layers
 
         public override IEnumerable<IFeature> GetFeaturesInView(BoundingBox box, double resolution)
         {
+            // Safeguard in case BoundingBox is null, most likely due to no features in layer
+            if (box == null) { return new List<IFeature>(); }
+
             var biggerBox = box.Grow(SymbolStyle.DefaultWidth * 2 * resolution, SymbolStyle.DefaultHeight * 2 * resolution);
             return DataSource.GetFeaturesInView(biggerBox, resolution);
         }


### PR DESCRIPTION
This can happen if no features have been added to a layer, since MemoryProvider.GetExtents() will not find any feature to create a BoundingBox, and return null:

```C#
public BoundingBox GetExtents()
{
    lock (_syncRoot)
    {
        BoundingBox box = null;
        foreach (IFeature feature in Features)
        {
            if (feature.Geometry.IsEmpty()) continue;
            box = box == null
                    ? feature.Geometry.GetBoundingBox()
                    : box.Join(feature.Geometry.GetBoundingBox());
        }
        return box;
    }
}
```

Which is then passed to `ILayer.Envelope`, and called from `InfoHelper.cs` at line 31.

I tried to compare with other GetFeaturesInView() implemented in MapsUI, and found returning an empty list of features to the most consistent choice. Hope that will be conform to what you expect 😄 