### PR TITLE
Add Triangle to available SymbolTypes

### DIFF
--- a/Mapsui.Rendering.Skia-PCL/PointRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/PointRenderer.cs
@@ -67,23 +67,28 @@ namespace Mapsui.Rendering.Skia
         private static void DrawPointWithVectorStyle(SKCanvas canvas, VectorStyle vectorStyle,
             SymbolType symbolType = SymbolType.Ellipse)
         {
-
-            var halfWidth = (float)SymbolStyle.DefaultWidth / 2;
+            var width = (float)SymbolStyle.DefaultWidth;
+            var halfWidth = width / 2;
             var halfHeight = (float)SymbolStyle.DefaultHeight / 2;
 
             var fillPaint = CreateFillPaint(vectorStyle.Fill);
 
             var linePaint = CreateLinePaint(vectorStyle.Outline);
 
-            if (symbolType == SymbolType.Rectangle)
+            switch (symbolType)
             {
-                var rect = new SKRect(-halfWidth, -halfHeight, halfWidth, halfHeight);
-                DrawRect(canvas, rect, fillPaint, linePaint);
-            }
-            else if (symbolType == SymbolType.Ellipse)
-            {
-
-                DrawCircle(canvas, 0, 0, halfWidth, fillPaint, linePaint);
+                case SymbolType.Ellipse:
+                    DrawCircle(canvas, 0, 0, halfWidth, fillPaint, linePaint);
+                    break;
+                case SymbolType.Rectangle:
+                    var rect = new SKRect(-halfWidth, -halfHeight, halfWidth, halfHeight);
+                    DrawRect(canvas, rect, fillPaint, linePaint);
+                    break;
+                case SymbolType.Triangle:
+                    DrawTriangle(canvas, 0, 0, width, fillPaint, linePaint);
+                    break;
+                default: // Invalid value
+                    throw new ArgumentOutOfRangeException();
             }
         }
 
@@ -123,6 +128,29 @@ namespace Mapsui.Rendering.Skia
         {
             if ((fillColor != null) && fillColor.Color.Alpha != 0) canvas.DrawRect(rect, fillColor);
             if ((lineColor != null) && lineColor.Color.Alpha != 0) canvas.DrawRect(rect, lineColor);
+        }
+
+        /// <summary>
+        /// Equilateral triangle of side 'sideLength', centered on the same point as if a circle of diameter 'sideLength' was there
+        /// </summary>
+        private static void DrawTriangle(SKCanvas canvas, float x, float y, float sideLength, SKPaint fillColor, SKPaint lineColor)
+        {
+            var altitude = Math.Sqrt(3) / 2.0 * sideLength;
+            var inradius = altitude / 3.0;
+            var circumradius = 2.0 * inradius;
+
+            var top = new Point(0, -circumradius);
+            var left = new Point(sideLength * -0.5, inradius);
+            var right = new Point(sideLength * 0.5, inradius);
+
+            var path = new SKPath();
+            path.MoveTo((float)top.X, (float)top.Y);
+            path.LineTo((float)left.X, (float)left.Y);
+            path.LineTo((float)right.X, (float)right.Y);
+            path.Close();
+
+            if ((fillColor != null) && fillColor.Color.Alpha != 0) canvas.DrawPath(path, fillColor);
+            if ((lineColor != null) && lineColor.Color.Alpha != 0) canvas.DrawPath(path, lineColor);
         }
 
         private static void DrawPointWithBitmapStyle(SKCanvas canvas, SymbolStyle symbolStyle, Point destination,

--- a/Mapsui.Rendering.Xaml/PointRenderer.cs
+++ b/Mapsui.Rendering.Xaml/PointRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using Mapsui.Styles;
 using Point = Mapsui.Geometries.Point;
+using System;
 using System.Windows;
 using XamlMedia = System.Windows.Media;
 using XamlShapes = System.Windows.Shapes;
@@ -56,10 +57,20 @@ namespace Mapsui.Rendering.Xaml
                 path.StrokeDashArray = style.Outline.PenStyle.ToXaml();
             }
 
-            if (symbolType == SymbolType.Ellipse)
-                path.Data = CreateEllipse(SymbolStyle.DefaultWidth, SymbolStyle.DefaultHeight);
-            else
-                path.Data = CreateRectangle(SymbolStyle.DefaultWidth, SymbolStyle.DefaultHeight);
+            switch (symbolType)
+            {
+                case SymbolType.Ellipse:
+                    path.Data = CreateEllipse(SymbolStyle.DefaultWidth, SymbolStyle.DefaultHeight);
+                    break;
+                case SymbolType.Rectangle:
+                    path.Data = CreateRectangle(SymbolStyle.DefaultWidth, SymbolStyle.DefaultHeight);
+                    break;
+                case SymbolType.Triangle:
+                    path.Data = CreateTriangle(SymbolStyle.DefaultWidth);
+                    break;
+                default: // Invalid value
+                    throw new ArgumentOutOfRangeException();
+            }                
 
             path.Opacity = opacity;
 
@@ -128,6 +139,32 @@ namespace Mapsui.Rendering.Xaml
             return new XamlMedia.RectangleGeometry
             {
                 Rect = new Rect(width * -0.5, height * -0.5, width, height)
+            };
+        }
+
+        /// <summary>
+        /// Equilateral triangle of side 'sideLength', centered on the same point as if a circle of diameter 'sideLength' was there
+        /// </summary>
+        private static XamlMedia.PathGeometry CreateTriangle(double sideLength)
+        {
+            var altitude = Math.Sqrt(3) / 2.0 * sideLength;
+            var inradius = altitude / 3.0;
+            var circumradius = 2.0 * inradius;
+
+            var top = new XamlPoint(0, -circumradius);
+            var left = new XamlPoint(sideLength * -0.5, inradius);
+            var right = new XamlPoint(sideLength * 0.5, inradius);
+
+            var segments = new XamlMedia.PathSegmentCollection();
+            segments.Add(new XamlMedia.LineSegment(left, true));
+            segments.Add(new XamlMedia.LineSegment(right, true));
+            var figure = new XamlMedia.PathFigure(top, segments, true);
+            var figures = new XamlMedia.PathFigureCollection();
+            figures.Add(figure);
+
+            return new XamlMedia.PathGeometry
+            {
+                Figures = figures
             };
         }
 

--- a/Mapsui/Styles/SymbolStyle.cs
+++ b/Mapsui/Styles/SymbolStyle.cs
@@ -6,7 +6,8 @@ namespace Mapsui.Styles
     public enum SymbolType
     {
         Ellipse,
-        Rectangle
+        Rectangle,
+        Triangle,
     }
 
     public enum UnitType

--- a/Tests/Mapsui.Rendering.Xaml.Tests/MapRendererTests.cs
+++ b/Tests/Mapsui.Rendering.Xaml.Tests/MapRendererTests.cs
@@ -71,7 +71,7 @@ namespace Mapsui.Rendering.Xaml.Tests
         public void RenderPointsWithDifferentSymbolTypes()
         {
             // arrange
-            var map = CircleAndSquareSymbolSample.CreateMap();
+            var map = SymbolTypesSample.CreateMap();
             const string fileName = "vector_symbol_symboltype.png";
             
             // act

--- a/Tests/Mapsui.Tests.Common/AllSamples.cs
+++ b/Tests/Mapsui.Tests.Common/AllSamples.cs
@@ -12,7 +12,7 @@ namespace Mapsui.Tests.Common
             {
                 StackedLabelsSample.CreateMap,
                 VectorStyleSample.CreateMap,
-                CircleAndSquareSymbolSample.CreateMap,
+                SymbolTypesSample.CreateMap,
                 BitmapSymbolSample.CreateMap,
                 BitmapSymbolWithRotationAndOffsetSample.CreateMap,
                 PointInWorldUnits.CreateMap,

--- a/Tests/Mapsui.Tests.Common/Maps/SymbolTypesSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/SymbolTypesSample.cs
@@ -58,6 +58,19 @@ namespace Mapsui.Tests.Common.Maps
                             SymbolType = SymbolType.Rectangle
                         }
                     }
+                },
+                new Feature
+                {
+                    Geometry = new Point(-20, 20),
+                    Styles = new List<IStyle>
+                    {
+                        new SymbolStyle
+                        {
+                            Fill = new Brush {Color = Color.Gray},
+                            Outline = new Pen(Color.Black),
+                            SymbolType = SymbolType.Triangle
+                        }
+                    }
                 }
             };
         }

--- a/Tests/Mapsui.Tests.Common/Maps/SymbolTypesSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/SymbolTypesSample.cs
@@ -6,7 +6,7 @@ using Mapsui.Styles;
 
 namespace Mapsui.Tests.Common.Maps
 {
-    public static class CircleAndSquareSymbolSample
+    public static class SymbolTypesSample
     {
         public static Map CreateMap()
         {
@@ -24,7 +24,7 @@ namespace Mapsui.Tests.Common.Maps
             map.Layers.Add(new MemoryLayer
             {
                 DataSource = new MemoryProvider(CreateFeatures()),
-                Name = "Circle and square symbols"
+                Name = "Symbol Types"
             });
             return map;
         }

--- a/Tests/Mapsui.Tests.Common/Mapsui.Tests.Common.csproj
+++ b/Tests/Mapsui.Tests.Common/Mapsui.Tests.Common.csproj
@@ -46,7 +46,7 @@
     <Compile Include="AllSamples.cs" />
     <Compile Include="Maps\BitmapSymbolSample.cs" />
     <Compile Include="Maps\BitmapSymbolWithRotationAndOffsetSample.cs" />
-    <Compile Include="Maps\CircleAndSquareSymbolSample.cs" />
+    <Compile Include="Maps\SymbolTypesSample.cs" />
     <Compile Include="Maps\EmptySample.cs" />
     <Compile Include="Maps\LabelSample.cs" />
     <Compile Include="Maps\LineSample.cs" />


### PR DESCRIPTION
Hi Paul! Ellipses and Rectangles are cool and all, but we hit a wall at some point due to having so many objects for different things on the map in our app. So we thought we'd add Triangles to spice things up a bit.

2 things to note:
- Since we only use Xaml and Skia, I only could add and test rendering on WPF apps.
- I couldn't figure out how to update the `vector_symbol_symboltype.png` for the `RenderPointsWithDifferentSymbolTypes` unit test.