### PR TITLE
Add tap count and handled property to the InfoEvent args

### DIFF
--- a/Mapsui.UI.Android/MapControl.cs
+++ b/Mapsui.UI.Android/MapControl.cs
@@ -70,13 +70,13 @@ namespace Mapsui.UI.Android
         private void OnDoubleTapped(object sender, GestureDetector.DoubleTapEventArgs e)
         {
             var position = GetScreenPosition(e.Event, this);
-            Map.InvokeInfo(position, position, _scale, _renderer.SymbolCache, WidgetTouched);
+            Map.InvokeInfo(position, position, _scale, _renderer.SymbolCache, WidgetTouched, 2);
         }
         
         private void OnSingleTapped(object sender, GestureDetector.SingleTapConfirmedEventArgs e)
         {
             var position = GetScreenPosition(e.Event, this);
-            Map.InvokeInfo(position, position, _scale, _renderer.SymbolCache, WidgetTouched);
+            Map.InvokeInfo(position, position, _scale, _renderer.SymbolCache, WidgetTouched, 1);
         }        
 
         protected override void OnSizeChanged(int w, int h, int oldw, int oldh)

--- a/Mapsui.UI.Uwp/MapControl.cs
+++ b/Mapsui.UI.Uwp/MapControl.cs
@@ -93,13 +93,13 @@ namespace Mapsui.UI.Uwp
         private void OnDoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
         {
             var tabPosition = e.GetPosition(this).ToMapsui();
-            Map.InvokeInfo(tabPosition, tabPosition, 1, _renderer.SymbolCache, WidgetTouched);
+            Map.InvokeInfo(tabPosition, tabPosition, 1, _renderer.SymbolCache, WidgetTouched, 2);
         }
 
         private void OnSingleTapped(object sender, TappedRoutedEventArgs e)
         {
             var tabPosition = e.GetPosition(this).ToMapsui();
-            Map.InvokeInfo(tabPosition, tabPosition, 1, _renderer.SymbolCache, WidgetTouched);
+            Map.InvokeInfo(tabPosition, tabPosition, 1, _renderer.SymbolCache, WidgetTouched, 1);
         }
 
         private static Rectangle CreateSelectRectangle()

--- a/Mapsui.UI.Wpf/MapControl.cs
+++ b/Mapsui.UI.Wpf/MapControl.cs
@@ -441,7 +441,7 @@ namespace Mapsui.UI.Wpf
         private void MapControlMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
             var mousePosition = e.GetPosition(this).ToMapsui();
-
+            
             if (IsInBoxZoomMode || ZoomToBoxMode)
             {
                 ZoomToBoxMode = false;
@@ -452,8 +452,7 @@ namespace Mapsui.UI.Wpf
             else
             {
                 HandleFeatureInfo(e);
-                Map.InvokeInfo(mousePosition, _downMousePosition.ToMapsui(), _scale, 
-                    Renderer.SymbolCache, OnWidgetTouched);
+                Map.InvokeInfo(mousePosition, _downMousePosition.ToMapsui(), _scale, Renderer.SymbolCache, OnWidgetTouched, e.ClickCount);
             }
 
             _map.ViewChanged(true);
@@ -470,7 +469,9 @@ namespace Mapsui.UI.Wpf
             {
                 var touchPosition = e.GetTouchPoint(this).Position.ToMapsui();
                 // todo: Pass the touchDown position. It needs to be set at touch down.
-                Map.InvokeInfo(touchPosition, touchPosition, _scale, Renderer.SymbolCache, OnWidgetTouched);
+                
+                // TODO Figure out how to do a number of taps for WPF
+                Map.InvokeInfo(touchPosition, touchPosition, _scale, Renderer.SymbolCache, OnWidgetTouched, 1);
             }
         }
 

--- a/Mapsui.UI.iOS/MapControl.cs
+++ b/Mapsui.UI.iOS/MapControl.cs
@@ -75,14 +75,20 @@ namespace Mapsui.UI.iOS
         {
             var screenPosition = GetScreenPosition(gesture.LocationInView(this));
 
-            Map.InvokeInfo(screenPosition, screenPosition, _skiaScale, _renderer.SymbolCache, WidgetTouched);
+            var tapWasHandled = Map.InvokeInfo(screenPosition, screenPosition, _skiaScale, _renderer.SymbolCache, WidgetTouched, 2);
+
+            if (!tapWasHandled)
+            {
+                // TODO 
+                // double tap zoom here
+            }
         }
 
         private void OnSingleTapped(UITapGestureRecognizer gesture)
         {
             var screenPosition = GetScreenPosition(gesture.LocationInView(this));
 
-            Map.InvokeInfo(screenPosition, screenPosition, _skiaScale, _renderer.SymbolCache, WidgetTouched);
+            Map.InvokeInfo(screenPosition, screenPosition, _skiaScale, _renderer.SymbolCache, WidgetTouched, 1);
         }
 
         void OnPaintSurface(object sender, SKPaintGLSurfaceEventArgs skPaintSurfaceEventArgs)

--- a/Mapsui/UI/InfoEventArgs.cs
+++ b/Mapsui/UI/InfoEventArgs.cs
@@ -23,5 +23,13 @@ namespace Mapsui.UI
         /// Screen position of the place the user touched
         /// </summary>
         public Point ScreenPosition { get; set; }
+        /// <summary>
+        /// Number of times the user tapped the location
+        /// </summary>
+        public int NumTaps { get; set; }
+        /// <summary>
+        /// If the interaction was handled but the event subscriber
+        /// </summary>
+        public bool Handled { get; set; }
     }
 }

--- a/Mapsui/UI/InfoEventArgs.cs
+++ b/Mapsui/UI/InfoEventArgs.cs
@@ -28,7 +28,7 @@ namespace Mapsui.UI
         /// </summary>
         public int NumTaps { get; set; }
         /// <summary>
-        /// If the interaction was handled but the event subscriber
+        /// If the interaction was handled by the event subscriber
         /// </summary>
         public bool Handled { get; set; }
     }

--- a/Mapsui/UI/InfoHelper.cs
+++ b/Mapsui/UI/InfoHelper.cs
@@ -12,15 +12,15 @@ namespace Mapsui.UI
     public static class InfoHelper
     {
         public static InfoEventArgs GetInfoEventArgs(IViewport viewport, Point screenPosition, 
-            float scale, IEnumerable<ILayer> layers, ISymbolCache symbolCache)
+            float scale, IEnumerable<ILayer> layers, ISymbolCache symbolCache, int numTaps)
         {
             var worldPosition = viewport.ScreenToWorld(
                 new Point(screenPosition.X / scale, screenPosition.Y / scale));
-            return GetInfoEventArgs(layers, worldPosition, screenPosition, viewport.Resolution, symbolCache);
+            return GetInfoEventArgs(layers, worldPosition, screenPosition, viewport.Resolution, symbolCache, numTaps);
         }
 
         private static InfoEventArgs GetInfoEventArgs(IEnumerable<ILayer> layers, Point worldPosition, Point screenPosition,
-            double resolution, ISymbolCache symbolCache)
+            double resolution, ISymbolCache symbolCache, int numTaps)
         {
             var reversedLayer = layers.Reverse();
             foreach (var layer in reversedLayer)
@@ -41,12 +41,14 @@ namespace Mapsui.UI
                         Feature = feature,
                         Layer = layer,
                         WorldPosition = worldPosition,
-                        ScreenPosition = screenPosition
+                        ScreenPosition = screenPosition,
+                        NumTaps = numTaps,
+                        Handled = false,
                     };
                 }
             }
             // return InfoEventArgs without feature if none was found. Can be usefull to create features
-            return new InfoEventArgs { WorldPosition = worldPosition, ScreenPosition = screenPosition};
+            return new InfoEventArgs { WorldPosition = worldPosition, ScreenPosition = screenPosition, NumTaps = numTaps, Handled = false};
         }
 
         private static bool IsTouchingTakingIntoAccountSymbolStyles(

--- a/Tests/Mapsui.Tests/UI/FeatureInfoTests.cs
+++ b/Tests/Mapsui.Tests/UI/FeatureInfoTests.cs
@@ -33,8 +33,8 @@ namespace Mapsui.Tests.UI
             var scale = 1;
 
             // act
-            var argsHit = InfoHelper.GetInfoEventArgs(map.Viewport, screenPositionHit, scale, map.InfoLayers, null);
-            var argsMis = InfoHelper.GetInfoEventArgs(map.Viewport, screenPositionMiss, scale, map.InfoLayers, null);
+            var argsHit = InfoHelper.GetInfoEventArgs(map.Viewport, screenPositionHit, scale, map.InfoLayers, null, 1);
+            var argsMis = InfoHelper.GetInfoEventArgs(map.Viewport, screenPositionMiss, scale, map.InfoLayers, null, 1);
 
             // assert;
             Assert.IsTrue(argsHit.Feature.Geometry != null);
@@ -121,7 +121,7 @@ namespace Mapsui.Tests.UI
             var scale = 1;
 
             // act
-            var argsHit = InfoHelper.GetInfoEventArgs(map.Viewport, screenPositionHit, scale, map.InfoLayers, null);
+            var argsHit = InfoHelper.GetInfoEventArgs(map.Viewport, screenPositionHit, scale, map.InfoLayers, null, 1);
            
             // assert;
             Assert.IsTrue(argsHit.Feature == null);
@@ -162,7 +162,7 @@ namespace Mapsui.Tests.UI
             var scale = 1;
 
             // act
-            var argsHit = InfoHelper.GetInfoEventArgs(map.Viewport, screenPositionHit, scale, map.InfoLayers, null);
+            var argsHit = InfoHelper.GetInfoEventArgs(map.Viewport, screenPositionHit, scale, map.InfoLayers, null, 1);
 
             // assert;
             Assert.IsTrue(argsHit.Feature == null);


### PR DESCRIPTION
This is to extend the info/hover system (hover sends 0 as numTaps), so that tap interactions that are unhandled can be used by the control to do future things like double tap zoom.

We could also use this to loop through the widgets and info items in order of their Z index (height) on the screen till the handled flag is triggered.

What do you guys think should happen here with the looping through widgets/info items until handled in the args is set to true?
@pauldendulk  
@charlenni 
