### PR TITLE
Extending Skia renderer to respect PenStrokeCap and PenStyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ project.lock.json
 /Tools/VersionUpdater.pdb
 /Tools/VersionUpdater.exe.config
 /Tools/VersionUpdater.exe
+/Mapsui.UI.Forms/Images/Pin.svg.bak

--- a/Mapsui.Rendering.Skia-PCL/ExtensionMethods/PenStyleExtension.cs
+++ b/Mapsui.Rendering.Skia-PCL/ExtensionMethods/PenStyleExtension.cs
@@ -1,0 +1,37 @@
+﻿using Mapsui.Styles;
+using SkiaSharp;
+
+namespace Mapsui.Rendering.Skia.ExtensionMethods
+{
+    public static class PenStyleExtension
+    {
+        public static SKPathEffect ToSkia(this PenStyle penStyle, float width)
+        {
+            switch (penStyle)
+            {
+                case PenStyle.Dash:
+                    return SKPathEffect.CreateDash(new float[2] { width * 4f, width * 3f }, 0);
+                case PenStyle.Dot:
+                    return SKPathEffect.CreateDash(new float[2] { width * 1f, width * 3f }, 0);
+                case PenStyle.DashDot:
+                    return SKPathEffect.CreateDash(new float[4] { width * 4f, width * 3f, width * 1f, width * 3f }, 0);
+                case PenStyle.DashDotDot:
+                    return SKPathEffect.CreateDash(new float[6] { width * 4f, width * 3f, width * 1f, width * 3f, width * 1f, width * 3f }, 0);
+                case PenStyle.LongDash:
+                    return SKPathEffect.CreateDash(new float[2] { width * 8f, width * 3f }, 0);
+                case PenStyle.LongDashDot:
+                    return SKPathEffect.CreateDash(new float[4] { width * 8f, width * 3f, width * 1f, width * 3f }, 0);
+                case PenStyle.ShortDash:
+                    return SKPathEffect.CreateDash(new float[2] { width * 2f, width * 3f }, 0);
+                case PenStyle.ShortDashDot:
+                    return SKPathEffect.CreateDash(new float[4] { width * 2f, width * 3f, width * 1f, width * 3f }, 0);
+                case PenStyle.ShortDashDotDot:
+                    return SKPathEffect.CreateDash(new float[6] { width * 2f, width * 3f, width * 1f, width * 3f, width * 1f, width * 3f }, 0);
+                case PenStyle.ShortDot:
+                    return SKPathEffect.CreateDash(new float[2] { width * 1f, width * 3f }, 0);
+                default:
+                    return SKPathEffect.CreateDash(new float[0], 0);
+            }
+        }
+    }
+}

--- a/Mapsui.Rendering.Skia-PCL/LineStringRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/LineStringRenderer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Mapsui.Geometries;
 using Mapsui.Providers;
+using Mapsui.Rendering.Skia.ExtensionMethods;
 using Mapsui.Styles;
 using SkiaSharp;
 
@@ -27,12 +28,14 @@ namespace Mapsui.Rendering.Skia
 
                 var vectorStyle = style as VectorStyle;
                 var strokeCap = PenStrokeCap.Butt;
+                var strokeStyle = PenStyle.Solid;
 
                 if (vectorStyle != null)
                 {
                     lineWidth = (float) vectorStyle.Line.Width;
                     lineColor = vectorStyle.Line.Color;
                     strokeCap = vectorStyle.Line.PenStrokeCap;
+                    strokeStyle = vectorStyle.Line.PenStyle;
                 }
 
                 var line = WorldToScreen(viewport, lineString);
@@ -45,7 +48,8 @@ namespace Mapsui.Rendering.Skia
                     paint.Color = lineColor.ToSkia(layerOpacity);
                     paint.StrokeJoin = SKStrokeJoin.Round;
                     paint.StrokeCap = strokeCap.ToSkia();
-
+                    if (strokeStyle != PenStyle.Solid)
+                        paint.PathEffect = strokeStyle.ToSkia(lineWidth);
                     canvas.DrawPath(path, paint);
                 }
             }

--- a/Mapsui.Rendering.Skia-PCL/Mapsui.Rendering.Skia-PCL.csproj
+++ b/Mapsui.Rendering.Skia-PCL/Mapsui.Rendering.Skia-PCL.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <Compile Include="ExtensionMethods\BoundingBoxExtensions.cs" />
     <Compile Include="ExtensionMethods\PenStrokeCapExtensions.cs" />
+    <Compile Include="ExtensionMethods\PenStyleExtension.cs" />
     <Compile Include="ExtensionMethods\SKRectExtensions.cs" />
     <Compile Include="HyperlinkWidgetRenderer.cs" />
     <Compile Include="ZoomInOutWidgetRenderer.cs" />

--- a/Mapsui.Rendering.Skia-PCL/PointRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/PointRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Mapsui.Geometries;
 using Mapsui.Providers;
+using Mapsui.Rendering.Skia.ExtensionMethods;
 using Mapsui.Styles;
 using SkiaSharp;
 
@@ -98,6 +99,8 @@ namespace Mapsui.Rendering.Skia
             {
                 Color = outline.Color.ToSkia(layerOpacity),
                 StrokeWidth = (float) outline.Width,
+                StrokeCap = outline.PenStrokeCap.ToSkia(),
+                PathEffect = outline.PenStyle.ToSkia((float)outline.Width),
                 Style = SKPaintStyle.Stroke,
                 IsAntialias = true
             };

--- a/Mapsui.Rendering.Skia-PCL/PolygonRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/PolygonRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using Mapsui.Geometries;
 using Mapsui.Providers;
+using Mapsui.Rendering.Skia.ExtensionMethods;
 using Mapsui.Styles;
 using SkiaSharp;
 
@@ -23,13 +24,18 @@ namespace Mapsui.Rendering.Skia
                 float lineWidth = 1;
                 var lineColor = Color.Black; // default
                 var fillColor = Color.Gray; // default
+                var strokeCap = PenStrokeCap.Butt; // default
+                var strokeStyle = PenStyle.Solid; // default
 
                 var vectorStyle = style as VectorStyle;
 
                 if (vectorStyle != null)
                 {
-                    lineWidth = (float) vectorStyle.Outline.Width;
+                    lineWidth = (float)vectorStyle.Outline.Width;
                     lineColor = vectorStyle.Outline.Color;
+                    strokeCap = vectorStyle.Outline.PenStrokeCap;
+                    strokeStyle = vectorStyle.Outline.PenStyle;
+
                     fillColor = vectorStyle.Fill?.Color;
                 }
 
@@ -45,6 +51,9 @@ namespace Mapsui.Rendering.Skia
                         canvas.DrawPath(path, paint);
                         paint.Style = SKPaintStyle.Stroke;
                         paint.Color = lineColor.ToSkia(layerOpacity);
+                        paint.StrokeCap = strokeCap.ToSkia();
+                        if (strokeStyle != PenStyle.Solid)
+                            paint.PathEffect = strokeStyle.ToSkia(lineWidth);
                         canvas.DrawPath(path, paint);
                     }
                 }

--- a/Samples/Mapsui.Samples.Common/Maps/PointsSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/PointsSample.cs
@@ -57,7 +57,7 @@ namespace Mapsui.Samples.Common.Maps
             return new Layer
             {
                 DataSource = new MemoryProvider(GenerateRandomPoints(envelope, count)),
-                Style = style ?? new VectorStyle { Fill = new Brush(Color.White) }
+                Style = style ?? new VectorStyle { Fill = new Brush(Color.White), Outline = new Pen { Color = Color.Black, PenStyle = PenStyle.Dash } }
             };
         }
     }

--- a/Samples/Mapsui.Samples.Common/Maps/PolygonSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/PolygonSample.cs
@@ -24,8 +24,13 @@ namespace Mapsui.Samples.Common.Maps
                 Style = new VectorStyle
                 {
                     Fill = new Brush(new Color(150, 150, 30, 128)),
-                    Outline = new Pen(Color.Orange, 2),
-                    
+                    Outline = new Pen
+                    {
+                        Color = Color.Orange,
+                        Width = 2,
+                        PenStyle = PenStyle.Solid,
+                        PenStrokeCap = PenStrokeCap.Round
+                    }
                 }
             };
         }


### PR DESCRIPTION
Respect PenStrokeCap and PenStyle in Skia render. Perhaps it is a fine adjustment for line width in PenStyleExtension.

Styles should be refactored. They are not very consistent.