### PR TITLE
Extend IStyle to include an opacity for all styles

### DIFF
--- a/Mapsui.Rendering.Skia-PCL/LineStringRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/LineStringRenderer.cs
@@ -10,13 +10,13 @@ namespace Mapsui.Rendering.Skia
     public static class LineStringRenderer
     {
         public static void Draw(SKCanvas canvas, IViewport viewport, IStyle style, IFeature feature, IGeometry geometry,
-            float layerOpacity)
+            float opacity)
         {
             if (style is LabelStyle labelStyle)
             {
                 var worldCenter = geometry.GetBoundingBox().GetCentroid();
                 var center = viewport.WorldToScreen(worldCenter);
-                LabelRenderer.Draw(canvas, labelStyle, feature, (float) center.X, (float) center.Y, layerOpacity);
+                LabelRenderer.Draw(canvas, labelStyle, feature, (float) center.X, (float) center.Y, opacity);
             }
             else
             {
@@ -45,7 +45,7 @@ namespace Mapsui.Rendering.Skia
                 {
                     paint.IsStroke = true;
                     paint.StrokeWidth = lineWidth;
-                    paint.Color = lineColor.ToSkia(layerOpacity);
+                    paint.Color = lineColor.ToSkia(opacity);
                     paint.StrokeJoin = SKStrokeJoin.Round;
                     paint.StrokeCap = strokeCap.ToSkia();
                     if (strokeStyle != PenStyle.Solid)

--- a/Mapsui.Rendering.Skia-PCL/MapRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/MapRenderer.cs
@@ -119,19 +119,19 @@ namespace Mapsui.Rendering.Skia
         private void RenderFeature(SKCanvas canvas, IViewport viewport, IStyle style, IFeature feature, float layerOpacity)
         {
             if (feature.Geometry is Point)
-                PointRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, _symbolCache, layerOpacity);
+                PointRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, _symbolCache, layerOpacity * style.Opacity);
             else if (feature.Geometry is MultiPoint)
-                MultiPointRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, _symbolCache, layerOpacity);
+                MultiPointRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, _symbolCache, layerOpacity * style.Opacity);
             else if (feature.Geometry is LineString)
-                LineStringRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, layerOpacity);
+                LineStringRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, layerOpacity * style.Opacity);
             else if (feature.Geometry is MultiLineString)
-                MultiLineStringRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, layerOpacity);
+                MultiLineStringRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, layerOpacity * style.Opacity);
             else if (feature.Geometry is Polygon)
-                PolygonRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, layerOpacity);
+                PolygonRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, layerOpacity * style.Opacity);
             else if (feature.Geometry is MultiPolygon)
-                MultiPolygonRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, layerOpacity);
+                MultiPolygonRenderer.Draw(canvas, viewport, style, feature, feature.Geometry, layerOpacity * style.Opacity);
             else if (feature.Geometry is IRaster)
-                RasterRenderer.Draw(canvas, viewport, style, feature, layerOpacity, _tileCache, _currentIteration);
+                RasterRenderer.Draw(canvas, viewport, style, feature, layerOpacity * style.Opacity, _tileCache, _currentIteration);
         }
 
         private void Render(object canvas, IViewport viewport, IEnumerable<IWidget> widgets, float layerOpacity)

--- a/Mapsui.Rendering.Skia-PCL/MultiLineStringRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/MultiLineStringRenderer.cs
@@ -8,13 +8,13 @@ namespace Mapsui.Rendering.Skia
     public static class MultiLineStringRenderer
     {
         public static void Draw(SKCanvas canvas, IViewport viewport, IStyle style, IFeature feature, IGeometry geometry,
-            float layerOpacity)
+            float opacity)
         {
             var multiLineString = (MultiLineString) geometry;
 
             foreach (var lineString in multiLineString)
             {
-                LineStringRenderer.Draw(canvas, viewport, style, feature, lineString, layerOpacity);
+                LineStringRenderer.Draw(canvas, viewport, style, feature, lineString, opacity);
             }
         }
     }

--- a/Mapsui.Rendering.Skia-PCL/MultiPointRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/MultiPointRenderer.cs
@@ -8,13 +8,13 @@ namespace Mapsui.Rendering.Skia
     public static class MultiPointRenderer
     {
         public static void Draw(SKCanvas canvas, IViewport viewport, IStyle style, IFeature feature,
-            IGeometry geometry, SymbolCache symbolCache, float layerOpacity)
+            IGeometry geometry, SymbolCache symbolCache, float opacity)
         {
             var multiPoint = (MultiPoint) geometry;
 
             foreach (var point in multiPoint)
             {
-                PointRenderer.Draw(canvas, viewport, style, feature, point, symbolCache, layerOpacity);
+                PointRenderer.Draw(canvas, viewport, style, feature, point, symbolCache, opacity);
             }
         }
     }

--- a/Mapsui.Rendering.Skia-PCL/MultiPolygonRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/MultiPolygonRenderer.cs
@@ -8,13 +8,13 @@ namespace Mapsui.Rendering.Skia
     public static class MultiPolygonRenderer
     {
         public static void Draw(SKCanvas canvas, IViewport viewport, IStyle style, IFeature feature, IGeometry geometry,
-            float layerOpacity)
+            float opacity)
         {
             var multiPolygon = (MultiPolygon) geometry;
 
             foreach (var polygon in multiPolygon)
             {
-                PolygonRenderer.Draw(canvas, viewport, style, feature, polygon, layerOpacity);
+                PolygonRenderer.Draw(canvas, viewport, style, feature, polygon, opacity);
             }
         }
     }

--- a/Mapsui.Rendering.Skia-PCL/PointRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/PointRenderer.cs
@@ -10,7 +10,7 @@ namespace Mapsui.Rendering.Skia
     static class PointRenderer
     {
         public static void Draw(SKCanvas canvas, IViewport viewport, IStyle style, IFeature feature, 
-            IGeometry geometry, SymbolCache symbolCache, float layerOpacity)
+            IGeometry geometry, SymbolCache symbolCache, float opacity)
         {
             var point = geometry as Point;
             var destination = viewport.WorldToScreen(point);
@@ -18,7 +18,7 @@ namespace Mapsui.Rendering.Skia
             if (style is LabelStyle labelStyle)    // case 1) LabelStyle
             {
                 LabelRenderer.Draw(canvas, labelStyle, feature, (float) destination.X, (float) destination.Y, 
-                    layerOpacity);
+                    opacity);
             }
             else if (style is SymbolStyle)
             {
@@ -26,16 +26,16 @@ namespace Mapsui.Rendering.Skia
 
                 if ( symbolStyle.BitmapId >= 0)   // case 2) Bitmap Style
                 {
-                    DrawPointWithBitmapStyle(canvas, symbolStyle, destination, symbolCache, layerOpacity);
+                    DrawPointWithBitmapStyle(canvas, symbolStyle, destination, symbolCache, opacity);
                 }
                 else                              // case 3) SymbolStyle without bitmap
                 {
-                    DrawPointWithSymbolStyle(canvas, symbolStyle, destination, layerOpacity, symbolStyle.SymbolType);
+                    DrawPointWithSymbolStyle(canvas, symbolStyle, destination, opacity, symbolStyle.SymbolType);
                 }
             }
             else if (style is VectorStyle)        // case 4) VectorStyle
             {
-                DrawPointWithVectorStyle(canvas, (VectorStyle) style, destination, layerOpacity);
+                DrawPointWithVectorStyle(canvas, (VectorStyle) style, destination, opacity);
             }
             else
             {
@@ -44,35 +44,35 @@ namespace Mapsui.Rendering.Skia
         }
 
         private static void DrawPointWithSymbolStyle(SKCanvas canvas, SymbolStyle style,
-            Point destination, float layerOpacity, SymbolType symbolType = SymbolType.Ellipse)
+            Point destination, float opacity, SymbolType symbolType = SymbolType.Ellipse)
         {
             canvas.Save();
             canvas.Translate((float)destination.X, (float)destination.Y);
             canvas.Scale((float)style.SymbolScale, (float)style.SymbolScale);
             canvas.Translate((float) style.SymbolOffset.X, (float) -style.SymbolOffset.Y);
-            DrawPointWithVectorStyle(canvas, style, layerOpacity * (float)style.Opacity, symbolType);
+            DrawPointWithVectorStyle(canvas, style, opacity, symbolType);
             canvas.Restore();
         }
 
         private static void DrawPointWithVectorStyle(SKCanvas canvas, VectorStyle vectorStyle,
-            Point destination, float layerOpacity, SymbolType symbolType = SymbolType.Ellipse)
+            Point destination, float opacity, SymbolType symbolType = SymbolType.Ellipse)
         {
             canvas.Save();
             canvas.Translate((float)destination.X, (float)destination.Y);
-            DrawPointWithVectorStyle(canvas, vectorStyle, layerOpacity, symbolType);
+            DrawPointWithVectorStyle(canvas, vectorStyle, opacity, symbolType);
             canvas.Restore();
         }
 
         private static void DrawPointWithVectorStyle(SKCanvas canvas, VectorStyle vectorStyle,
-            float layerOpacity, SymbolType symbolType = SymbolType.Ellipse)
+            float opacity, SymbolType symbolType = SymbolType.Ellipse)
         {
             var width = (float)SymbolStyle.DefaultWidth;
             var halfWidth = width / 2;
             var halfHeight = (float)SymbolStyle.DefaultHeight / 2;
 
-            var fillPaint = CreateFillPaint(vectorStyle.Fill, layerOpacity);
+            var fillPaint = CreateFillPaint(vectorStyle.Fill, opacity);
 
-            var linePaint = CreateLinePaint(vectorStyle.Outline, layerOpacity);
+            var linePaint = CreateLinePaint(vectorStyle.Outline, opacity);
 
             switch (symbolType)
             {
@@ -91,13 +91,13 @@ namespace Mapsui.Rendering.Skia
             }
         }
 
-        private static SKPaint CreateLinePaint(Pen outline, float layerOpacity)
+        private static SKPaint CreateLinePaint(Pen outline, float opacity)
         {
             if (outline == null) return null;
 
             return new SKPaint
             {
-                Color = outline.Color.ToSkia(layerOpacity),
+                Color = outline.Color.ToSkia(opacity),
                 StrokeWidth = (float) outline.Width,
                 StrokeCap = outline.PenStrokeCap.ToSkia(),
                 PathEffect = outline.PenStyle.ToSkia((float)outline.Width),
@@ -106,13 +106,13 @@ namespace Mapsui.Rendering.Skia
             };
         }
 
-        private static SKPaint CreateFillPaint(Brush fill, float layerOpacity)
+        private static SKPaint CreateFillPaint(Brush fill, float opacity)
         {
             if (fill == null) return null;
 
             return new SKPaint
             {
-                Color = fill.Color.ToSkia(layerOpacity),
+                Color = fill.Color.ToSkia(opacity),
                 Style = SKPaintStyle.Fill,
                 IsAntialias = true
             };
@@ -155,7 +155,7 @@ namespace Mapsui.Rendering.Skia
         }
 
         private static void DrawPointWithBitmapStyle(SKCanvas canvas, SymbolStyle symbolStyle, Point destination,
-            SymbolCache symbolCache, float layerOpacity)
+            SymbolCache symbolCache, float opacity)
         {
             var bitmap = symbolCache.GetOrCreate(symbolStyle.BitmapId);
 
@@ -163,7 +163,7 @@ namespace Mapsui.Rendering.Skia
                 (float) destination.X, (float) destination.Y,
                 (float) symbolStyle.SymbolRotation,
                 (float) symbolStyle.SymbolOffset.X, (float) symbolStyle.SymbolOffset.Y,
-                opacity: (float) symbolStyle.Opacity * layerOpacity, scale: (float) symbolStyle.SymbolScale);
+                opacity: opacity, scale: (float) symbolStyle.SymbolScale);
         }
 
         

--- a/Mapsui.Rendering.Skia-PCL/PolygonRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/PolygonRenderer.cs
@@ -9,13 +9,13 @@ namespace Mapsui.Rendering.Skia
     internal static class PolygonRenderer
     {
         public static void Draw(SKCanvas canvas, IViewport viewport, IStyle style, IFeature feature, IGeometry geometry,
-            float layerOpacity)
+            float opacity)
         {
             if (style is LabelStyle)
             {
                 var worldCenter = geometry.GetBoundingBox().GetCentroid();
                 var center = viewport.WorldToScreen(worldCenter);
-                LabelRenderer.Draw(canvas, (LabelStyle)style, feature, (float)center.X, (float)center.Y, layerOpacity);
+                LabelRenderer.Draw(canvas, (LabelStyle)style, feature, (float)center.X, (float)center.Y, opacity);
             }
             else
             {
@@ -47,10 +47,10 @@ namespace Mapsui.Rendering.Skia
                         paint.StrokeWidth = lineWidth;
 
                         paint.Style = SKPaintStyle.Fill;
-                        paint.Color = fillColor.ToSkia(layerOpacity);
+                        paint.Color = fillColor.ToSkia(opacity);
                         canvas.DrawPath(path, paint);
                         paint.Style = SKPaintStyle.Stroke;
-                        paint.Color = lineColor.ToSkia(layerOpacity);
+                        paint.Color = lineColor.ToSkia(opacity);
                         paint.StrokeCap = strokeCap.ToSkia();
                         if (strokeStyle != PenStyle.Solid)
                             paint.PathEffect = strokeStyle.ToSkia(lineWidth);

--- a/Mapsui.Rendering.Skia-PCL/RasterRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/RasterRenderer.cs
@@ -11,7 +11,7 @@ namespace Mapsui.Rendering.Skia
     public static class RasterRenderer
     {
 		public static void Draw (SKCanvas canvas, IViewport viewport, IStyle style, IFeature feature,
-            float layerOpacity, IDictionary<object, BitmapInfo> tileCache, long currentIteration)
+            float opacity, IDictionary<object, BitmapInfo> tileCache, long currentIteration)
 		{
 		    try
 		    {
@@ -44,14 +44,14 @@ namespace Mapsui.Rendering.Skia
 
 		            var destination = new BoundingBox(0.0, 0.0, boundingBox.Width, boundingBox.Height);
 
-		            BitmapHelper.RenderRaster(canvas, bitmapInfo.Bitmap, destination.ToSkia(), layerOpacity);
+		            BitmapHelper.RenderRaster(canvas, bitmapInfo.Bitmap, destination.ToSkia(), opacity);
 
 		            canvas.SetMatrix(priorMatrix);
 		        }
 		        else
 		        {
 		            var destination = WorldToScreen(viewport, feature.Geometry.GetBoundingBox());
-		            BitmapHelper.RenderRaster(canvas, bitmapInfo.Bitmap, RoundToPixel(destination).ToSkia(), layerOpacity);
+		            BitmapHelper.RenderRaster(canvas, bitmapInfo.Bitmap, RoundToPixel(destination).ToSkia(), opacity);
                 }
 		    }
 			catch (Exception ex)

--- a/Mapsui.Rendering.Xaml/GeometryRenderer.cs
+++ b/Mapsui.Rendering.Xaml/GeometryRenderer.cs
@@ -55,7 +55,7 @@ namespace Mapsui.Rendering.Xaml
             // style.SymbolOffset.Convert();
             // style.SymbolRotation;
 
-            var path = new XamlShapes.Path();
+            var path = new XamlShapes.Path { Opacity = style.Opacity };
 
             if (style.BitmapId < 0)
             {

--- a/Mapsui.Rendering.Xaml/LabelRenderer.cs
+++ b/Mapsui.Rendering.Xaml/LabelRenderer.cs
@@ -42,7 +42,8 @@ namespace Mapsui.Rendering.Xaml
             {
                 Background = labelStyle.BackColor.ToXaml(),
                 CornerRadius = new CornerRadius(4),
-                Child = textblock
+                Child = textblock,
+                Opacity = labelStyle.Opacity,
             };
 
             DetermineTextWidthAndHeightWpf(out var textWidth, out var textHeight, labelStyle, labelText);

--- a/Mapsui.Rendering.Xaml/LineStringRenderer.cs
+++ b/Mapsui.Rendering.Xaml/LineStringRenderer.cs
@@ -21,7 +21,7 @@ namespace Mapsui.Rendering.Xaml
 
         public static System.Windows.Shapes.Path CreateLineStringPath(VectorStyle style)
         {
-            var path = new System.Windows.Shapes.Path();
+            var path = new System.Windows.Shapes.Path { Opacity = style.Opacity };
             if (style.Outline != null)
             {
                 //todo: render an outline around the line. 

--- a/Mapsui.Rendering.Xaml/PolygonRenderer.cs
+++ b/Mapsui.Rendering.Xaml/PolygonRenderer.cs
@@ -25,7 +25,7 @@ namespace Mapsui.Rendering.Xaml
 
         public static System.Windows.Shapes.Path CreatePolygonPath(VectorStyle style, double resolution, SymbolCache symbolCache)
         {
-            var path = new System.Windows.Shapes.Path();
+            var path = new System.Windows.Shapes.Path { Opacity = style.Opacity };
 
             if (style.Outline != null)
             {

--- a/Mapsui/Styles/IStyle.cs
+++ b/Mapsui/Styles/IStyle.cs
@@ -36,5 +36,10 @@ namespace Mapsui.Styles
 		/// Gets or sets whether objects in this style is rendered or not
 		/// </summary>
 		bool Enabled { get; set; }
+
+        /// <summary>
+		/// Gets or sets the objects overall opacity
+		/// </summary>
+		float Opacity { get; set; }
     }
 }

--- a/Mapsui/Styles/Style.cs
+++ b/Mapsui/Styles/Style.cs
@@ -28,6 +28,7 @@ namespace Mapsui.Styles
             MinVisible = 0;
             MaxVisible = double.MaxValue;
             Enabled = true;
+            Opacity = 1f;
         }
 
         /// <summary>
@@ -45,6 +46,10 @@ namespace Mapsui.Styles
         /// </summary>
         public bool Enabled { get; set; }
 
+        /// <summary>
+        ///     Gets or sets the objects base opacity
+        /// </summary>
+        public float Opacity { get; set; }
 
         public override bool Equals(object obj)
         {
@@ -71,7 +76,7 @@ namespace Mapsui.Styles
 
         public override int GetHashCode()
         {
-            return MinVisible.GetHashCode() ^ MaxVisible.GetHashCode() ^ Enabled.GetHashCode();
+            return MinVisible.GetHashCode() ^ MaxVisible.GetHashCode() ^ Enabled.GetHashCode() ^ Opacity.GetHashCode();
         }
 
         public static bool operator ==(Style style1, Style style2)

--- a/Mapsui/Styles/StyleCollection.cs
+++ b/Mapsui/Styles/StyleCollection.cs
@@ -7,5 +7,6 @@ namespace Mapsui.Styles
         public double MinVisible { get; set; }
         public double MaxVisible { get; set; }
         public bool Enabled  { get; set; }
+        public float Opacity { get; set; }
     }
 }

--- a/Mapsui/Styles/SymbolStyle.cs
+++ b/Mapsui/Styles/SymbolStyle.cs
@@ -27,7 +27,6 @@ namespace Mapsui.Styles
         {
             SymbolOffset = new Offset();
             SymbolScale = 1f;
-            Opacity = 1f;
             BitmapId = -1;
         }
 
@@ -62,8 +61,6 @@ namespace Mapsui.Styles
         public UnitType UnitType { get; set; }
 
         public SymbolType SymbolType { get; set; }
-
-        public double Opacity { get; set; }
 
         public override bool Equals(object obj)
         {
@@ -113,7 +110,6 @@ namespace Mapsui.Styles
                 SymbolRotation.GetHashCode() ^
                 UnitType.GetHashCode() ^
                 SymbolType.GetHashCode() ^
-                Opacity.GetHashCode() ^
                 base.GetHashCode();
         }
 

--- a/Samples/Mapsui.Samples.Android/Activity1.cs
+++ b/Samples/Mapsui.Samples.Android/Activity1.cs
@@ -36,7 +36,7 @@ namespace Mapsui.Samples.Android
             MbTilesSample.MbTilesLocation = MbTilesLocationOnAndroid;
             
             var mapControl = FindViewById<MapControl>(Resource.Id.mapcontrol);
-            mapControl.Map = OsmSample.CreateMap();
+            mapControl.Map = OpacityStyleSample.CreateMap();
             mapControl.Map.Info+= MapOnInfo;
             mapControl.Map.Viewport.ViewportChanged += ViewportOnViewportChanged;
             mapControl.AllowPinchRotation = true;

--- a/Samples/Mapsui.Samples.Android/Resources/Resource.Designer.cs
+++ b/Samples/Mapsui.Samples.Android/Resources/Resource.Designer.cs
@@ -26,18 +26,12 @@ namespace Mapsui.Samples.Android
 		
 		public static void UpdateIdValues()
 		{
-			global::Mapsui.UI.Android.Resource.Attribute.start_with_openstreetmap = global::Mapsui.Samples.Android.Resource.Attribute.start_with_openstreetmap;
 			global::Mapsui.UI.Android.Resource.String.ApplicationName = global::Mapsui.Samples.Android.Resource.String.ApplicationName;
 			global::Mapsui.UI.Android.Resource.String.Hello = global::Mapsui.Samples.Android.Resource.String.Hello;
-			global::Mapsui.UI.Android.Resource.Styleable.start_with_openstreetmap_style = global::Mapsui.Samples.Android.Resource.Styleable.start_with_openstreetmap_style;
-			global::Mapsui.UI.Android.Resource.Styleable.start_with_openstreetmap_style_start_with_openstreetmap = global::Mapsui.Samples.Android.Resource.Styleable.start_with_openstreetmap_style_start_with_openstreetmap;
 		}
 		
 		public partial class Attribute
 		{
-			
-			// aapt resource value: 0x7f010000
-			public const int start_with_openstreetmap = 2130771968;
 			
 			static Attribute()
 			{
@@ -118,25 +112,6 @@ namespace Mapsui.Samples.Android
 			}
 			
 			private String()
-			{
-			}
-		}
-		
-		public partial class Styleable
-		{
-			
-			public static int[] start_with_openstreetmap_style = new int[] {
-					2130771968};
-			
-			// aapt resource value: 0
-			public const int start_with_openstreetmap_style_start_with_openstreetmap = 0;
-			
-			static Styleable()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Styleable()
 			{
 			}
 		}

--- a/Samples/Mapsui.Samples.Common/AllSamples.cs
+++ b/Samples/Mapsui.Samples.Common/AllSamples.cs
@@ -35,7 +35,8 @@ namespace Mapsui.Samples.Common
                 ["Mutating triangle"] = MutatingTriangleSample.CreateMap,
                 ["Symbols in World Units"] = SymbolsInWorldUnitsSample.CreateMap,
                 ["Widgets"] = WidgetSample.CreateMap,
-                ["ScaleBar"] = ScaleBarSample.CreateMap
+                ["ScaleBar"] = ScaleBarSample.CreateMap,
+                ["OpacityStyle"] = OpacityStyleSample.CreateMap
             };
         }
     }

--- a/Samples/Mapsui.Samples.Common/Maps/OpacityStyleSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/OpacityStyleSample.cs
@@ -1,0 +1,87 @@
+﻿using Mapsui.Geometries;
+using Mapsui.Layers;
+using Mapsui.Providers;
+using Mapsui.Styles;
+using Mapsui.Utilities;
+
+namespace Mapsui.Samples.Common.Maps
+{
+    public static class OpacityStyleSample
+    {
+        public static Map CreateMap()
+        {
+            var map = new Map();
+            map.Layers.Add(OpenStreetMap.CreateTileLayer());
+            map.Layers.Add(CreatePolygonLayer());
+            map.Layers.Add(CreateLineStringLayer());
+            return map;
+        }
+
+        public static ILayer CreatePolygonLayer()
+        {
+            return new Layer("Polygons")
+            {
+                DataSource = new MemoryProvider(CreatePolygon()),
+                Style = new VectorStyle
+                {
+                    Fill = new Brush(new Color(150, 150, 30)),
+                    Outline = new Pen
+                    {
+                        Color = Color.Orange,
+                        Width = 2,
+                        PenStyle = PenStyle.Solid,
+                        PenStrokeCap = PenStrokeCap.Round
+                    },
+                    Opacity = 0.7f,
+                }
+            };
+        }
+        public static ILayer CreateLineStringLayer()
+        {
+            return new Layer("Polygons")
+            {
+                DataSource = new MemoryProvider(CreateLineString()),
+                Style = new VectorStyle
+                {
+                    Line = new Pen
+                    {
+                        Color = new Color(new Color(30, 150, 150)),
+                        PenStrokeCap = PenStrokeCap.Round,
+                        PenStyle = PenStyle.Solid,
+                        Width = 10,
+                    },
+                    Opacity = 0.5f,
+                }
+            };
+        }
+
+        private static Polygon CreatePolygon()
+        {
+            var polygon = new Polygon();
+            polygon.ExteriorRing.Vertices.Add(new Point(0, 0));
+            polygon.ExteriorRing.Vertices.Add(new Point(0, 10000000));
+            polygon.ExteriorRing.Vertices.Add(new Point(10000000, 10000000));
+            polygon.ExteriorRing.Vertices.Add(new Point(10000000, 0));
+            polygon.ExteriorRing.Vertices.Add(new Point(0, 0));
+            var linearRing = new LinearRing();
+            linearRing.Vertices.Add(new Point(1000000, 1000000));
+            linearRing.Vertices.Add(new Point(9000000, 1000000));
+            linearRing.Vertices.Add(new Point(9000000, 9000000));
+            linearRing.Vertices.Add(new Point(1000000, 9000000));
+            linearRing.Vertices.Add(new Point(1000000, 1000000));
+            polygon.InteriorRings.Add(linearRing);
+            return polygon;
+        }
+
+        private static LineString CreateLineString()
+        {
+            var lineString = new LineString();
+            lineString.Vertices.Add(new Point(1000000, 1000000));
+            lineString.Vertices.Add(new Point(9000000, 1000000));
+            lineString.Vertices.Add(new Point(9000000, 9000000));
+            lineString.Vertices.Add(new Point(1000000, 9000000));
+            lineString.Vertices.Add(new Point(1000000, 1000000));
+            return lineString;
+        }
+    }
+}

--- a/Samples/Mapsui.Samples.Common/Mapsui.Samples.Common.csproj
+++ b/Samples/Mapsui.Samples.Common/Mapsui.Samples.Common.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Maps\LabelsSample.cs" />
     <Compile Include="Maps\MbTilesSample.cs" />
     <Compile Include="Maps\MutatingTriangleSample.cs" />
+    <Compile Include="Maps\OpacityStyleSample.cs" />
     <Compile Include="Maps\ScaleBarSample.cs" />
     <Compile Include="Maps\OsmSample.cs" />
     <Compile Include="Maps\InfoLayersSample.cs" />


### PR DESCRIPTION
Moved the opacity of styles all the way down to the IStyle interface. Then implemented the opacity for all the things. If you think I missed one let me know, I added a basic sample, that could probably have more types of things added to it so that it proves the opacity model better.