### PR TITLE
Change Mapsui.Geometries.LineString.Vertices type from List to IList

### DIFF
--- a/Mapsui.Geometries/LineString.cs
+++ b/Mapsui.Geometries/LineString.cs
@@ -61,7 +61,7 @@ namespace Mapsui.Geometries
         /// <summary>
         ///     Gets or sets the collection of vertices in this Geometry
         /// </summary>
-        public List<Point> Vertices { get; set; }
+        public IList<Point> Vertices { get; set; }
 
         /// <summary>
         ///     Returns the vertice where this Geometry begins

--- a/Mapsui.Geometries/Utilities/Algorithms.cs
+++ b/Mapsui.Geometries/Utilities/Algorithms.cs
@@ -152,7 +152,7 @@ namespace Mapsui.Geometries.Utilities
             return disc > 0.0;
         }
 
-        public static bool PointInPolygon(List<Point> ring, Point point)
+        public static bool PointInPolygon(IList<Point> ring, Point point)
         {
             // taken from: http://stackoverflow.com/a/2922778/85325
             var result = false;
@@ -167,7 +167,7 @@ namespace Mapsui.Geometries.Utilities
             return result;
         }
 
-        public static double DistanceToLine(Point point, List<Point> points)
+        public static double DistanceToLine(Point point, IList<Point> points)
         {
             var minDist = Double.MaxValue;
 


### PR DESCRIPTION
This makes it possible to set Vertices to an instance of another class which implements IList, e.g. an ObservableCollection. 

(We use this in an application in which the end-user can edit polygons)
