### PR TITLE
Several Geometry additions/changes

### DIFF
--- a/Mapsui.Geometries/LineString.cs
+++ b/Mapsui.Geometries/LineString.cs
@@ -241,5 +241,23 @@ namespace Mapsui.Geometries
             if (lineString == null) return false;
             return Equals(lineString);
         }
+
+
+        /// <summary>
+        ///     Returns a list of line string segments
+        /// </summary>
+        /// <returns>List of LineString</returns>
+        public List<LineString> GetSegments()
+        {
+            List<LineString> segments = new List<LineString>();
+            for (int i = 0; i < this.Vertices.Count - 1; i++)
+            {
+                LineString tmp = new LineString();
+                tmp.Vertices.Add(Vertices[i]);
+                tmp.Vertices.Add(Vertices[i + 1]);
+                segments.Add(tmp);
+            }
+            return segments;
+        }
     }
 }

--- a/Mapsui.Geometries/LinearRing.cs
+++ b/Mapsui.Geometries/LinearRing.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Mapsui.Geometries
 {
@@ -69,6 +70,8 @@ namespace Mapsui.Geometries
                 return Math.Abs(-sum/2);
             }
         }
+
+        public new static bool IsClosed => true; // LinearRing is closed by definition
 
         /// <summary>
         ///     Return a copy of this geometry
@@ -161,6 +164,27 @@ namespace Mapsui.Geometries
             return c;
         }
 
+        /// <summary>
+        ///     Returns a clone of the LinearRing as LineString
+        /// </summary>
+        /// <returns>LineString</returns>
+        public LineString GetLineString()
+        {
+            // Make deep copy
+            var tmpLineString = Clone();
+
+            // Check if first vertex is approximately equal to last vertex
+            if (Math.Abs(tmpLineString.StartPoint.X - tmpLineString.EndPoint.X) > Double.Epsilon ||
+                Math.Abs(tmpLineString.StartPoint.Y - tmpLineString.EndPoint.Y) > Double.Epsilon)
+            {
+                tmpLineString.Vertices.Add(tmpLineString.Vertices.First());
+            }
+
+            return tmpLineString;
+        }
+
+
+        
         public LinearRing Rotate(double degrees, Point center)
         {
             var rotatedLinearRing = this.Clone();

--- a/Mapsui.Geometries/Utilities/Algorithms.cs
+++ b/Mapsui.Geometries/Utilities/Algorithms.cs
@@ -35,6 +35,11 @@ namespace Mapsui.Geometries.Utilities
             return Math.Sqrt(Math.Pow(x1 - x2, 2.0) + Math.Pow(y1 - y2, 2.0));
         }
 
+        public static double Distance(Point a, Point b)
+        {
+            return Math.Sqrt(Math.Pow(a.X - b.X, 2.0) + Math.Pow(a.Y - b.Y, 2.0));
+        }
+
         /// <summary>
         ///     Converts the specified angle from degrees to radians
         /// </summary>

--- a/Mapsui/Projection/BoundingBoxIterator.cs
+++ b/Mapsui/Projection/BoundingBoxIterator.cs
@@ -12,7 +12,7 @@ namespace Mapsui.Projection
 
         public static IEnumerable<Point> GetCornerVertices(this BoundingBox boundingBox)
         {
-            return new[] { boundingBox.BottomLeft, boundingBox.BottomRight, boundingBox.TopRight, boundingBox.TopLeft };
+            return new[] { boundingBox.BottomLeft, boundingBox.TopLeft, boundingBox.TopRight, boundingBox.BottomRight};
         }
     }
 }

--- a/Mapsui/Projection/BoundingBoxIterator.cs
+++ b/Mapsui/Projection/BoundingBoxIterator.cs
@@ -9,5 +9,10 @@ namespace Mapsui.Projection
         {
             return new[] { boundingBox.Min, boundingBox.Max };
         }
+
+        public static IEnumerable<Point> GetCornerVertices(this BoundingBox boundingBox)
+        {
+            return new[] { boundingBox.BottomLeft, boundingBox.BottomRight, boundingBox.TopRight, boundingBox.TopLeft };
+        }
     }
 }


### PR DESCRIPTION
Non-breaking:
- Added Algorithms.Distance overload for two Geometries.Points (instead of 4 doubles).   
- Added method to get the segments (individual two-point lines) of a LineString.
- Added method to create a (closed) LineString from a LinearRing.

Breaking:
- LinearRing.IsClosed always returns true now, as a LinearRing is closed by definition, even if the StartPoint and EndPoint are not geometrically equal. **This might be breaking.**  Just remove this change if you think this can be a problem for anyone.