### PR TITLE
Fixed Skia renderer pixelated scaling issue

### DIFF
--- a/Mapsui.Rendering.Skia-PCL/BitmapHelper.cs
+++ b/Mapsui.Rendering.Skia-PCL/BitmapHelper.cs
@@ -9,6 +9,7 @@ namespace Mapsui.Rendering.Skia
     public static class BitmapHelper
     {
         private static readonly SKPaint Paint = new SKPaint(); // Reuse for performance. Only for opacity
+        private static readonly SKPaint QualityPaint = new SKPaint() { FilterQuality = SKFilterQuality.Low }; // Only for high/med/low quality resizing of tiles
 
         public static BitmapInfo LoadBitmap(Stream bitmapStream, bool isSvg = false)
         {
@@ -128,7 +129,7 @@ namespace Mapsui.Rendering.Skia
             }
             else
             {
-                canvas.DrawImage(bitmap, rect);
+                canvas.DrawImage(bitmap, rect, QualityPaint);
             }
             
         }


### PR DESCRIPTION
Skia render shows pixelated tiles as the user zooms in #352. This is probably due to the nearest neighbor scaling algorithm.

![pixelated3](https://user-images.githubusercontent.com/8333794/38160875-a35cc5a2-34dd-11e8-92c5-4eff0d46201b.gif)

The fix in this pull request uses an anti-aliased paint to draw the tiles. The quality is set to low, and the paint is cached to make sure that the performance impact is minimal and the tile isn't pixelated either.