### PR TITLE
Changed new from Atlas to Sprite for better understanding

### DIFF
--- a/Mapsui.Rendering.Skia-PCL/BitmapHelper.cs
+++ b/Mapsui.Rendering.Skia-PCL/BitmapHelper.cs
@@ -32,9 +32,9 @@ namespace Mapsui.Rendering.Skia
                 return new BitmapInfo {Bitmap = image};
             }
 
-            if (bitmapStream is Atlas atlas)
+            if (bitmapStream is Sprite sprite)
             {
-                return new BitmapInfo() {Atlas = atlas};
+                return new BitmapInfo() {Sprite = sprite};
             }
 
             return null;

--- a/Mapsui.Rendering.Skia-PCL/BitmapInfo.cs
+++ b/Mapsui.Rendering.Skia-PCL/BitmapInfo.cs
@@ -7,7 +7,7 @@ namespace Mapsui.Rendering.Skia
     {
         Bitmap,
         Svg,
-        Atlas
+        Sprite
     }
 
     public class BitmapInfo
@@ -48,19 +48,19 @@ namespace Mapsui.Rendering.Skia
             }
         }
 
-        public Atlas Atlas
+        public Sprite Sprite
         {
             get
             {
-                if (Type == BitmapType.Atlas)
-                    return (Atlas)data;
+                if (Type == BitmapType.Sprite)
+                    return (Sprite)data;
                 else
                     return null;
             }
             set
             {
                 data = value;
-                Type = BitmapType.Atlas;
+                Type = BitmapType.Sprite;
             }
         }
 
@@ -76,8 +76,8 @@ namespace Mapsui.Rendering.Skia
                         return Bitmap.Width;
                     case BitmapType.Svg:
                         return Svg.CanvasSize.Width;
-                    case BitmapType.Atlas:
-                        return ((Atlas) data).Width;
+                    case BitmapType.Sprite:
+                        return ((Sprite) data).Width;
                     default:
                         return 0;
                 }
@@ -94,8 +94,8 @@ namespace Mapsui.Rendering.Skia
                         return Bitmap.Height;
                     case BitmapType.Svg:
                         return Svg.CanvasSize.Height;
-                    case BitmapType.Atlas:
-                        return ((Atlas) data).Height;
+                    case BitmapType.Sprite:
+                        return ((Sprite) data).Height;
                     default:
                         return 0;
                 }

--- a/Mapsui.Rendering.Skia-PCL/PointRenderer.cs
+++ b/Mapsui.Rendering.Skia-PCL/PointRenderer.cs
@@ -181,15 +181,15 @@ namespace Mapsui.Rendering.Skia
                         (float)offsetX, (float)offsetY,
                         opacity: opacity, scale: (float)symbolStyle.SymbolScale);
                     break;
-                case BitmapType.Atlas:
-                    var atlas = bitmap.Atlas;
-                    if (atlas.Data == null)
+                case BitmapType.Sprite:
+                    var sprite = bitmap.Sprite;
+                    if (sprite.Data == null)
                     {
-                        var bitmapAtlas = symbolCache.GetOrCreate(atlas.BitmapId);
-                        atlas.Data = bitmapAtlas.Bitmap.Subset(new SKRectI(atlas.X, atlas.Y, atlas.X + atlas.Width,
-                            atlas.Y + atlas.Height));
+                        var bitmapAtlas = symbolCache.GetOrCreate(sprite.Atlas);
+                        sprite.Data = bitmapAtlas.Bitmap.Subset(new SKRectI(sprite.X, sprite.Y, sprite.X + sprite.Width,
+                            sprite.Y + sprite.Height));
                     }
-                    BitmapHelper.RenderBitmap(canvas, (SKImage)atlas.Data,
+                    BitmapHelper.RenderBitmap(canvas, (SKImage)sprite.Data,
                         (float)destination.X, (float)destination.Y,
                         (float)symbolStyle.SymbolRotation,
                         (float)offsetX, (float)offsetY,

--- a/Mapsui.Rendering.Xaml/SymbolCache.cs
+++ b/Mapsui.Rendering.Xaml/SymbolCache.cs
@@ -15,13 +15,13 @@ namespace Mapsui.Rendering.Xaml
 
             var obj = BitmapRegistry.Instance.Get(bitmapId);
 
-            if (obj is Atlas atlas)
+            if (obj is Sprite sprite)
             {
-                if (GetOrCreate(atlas.BitmapId) == null)
+                if (GetOrCreate(sprite.Atlas) == null)
                     throw new AccessViolationException("Atlas bitmap unknown");
 
-                var bitmapSource = new CroppedBitmap((BitmapImage)GetOrCreate(atlas.BitmapId),
-                    new System.Windows.Int32Rect(atlas.X, atlas.Y, atlas.Width, atlas.Height));
+                var bitmapSource = new CroppedBitmap((BitmapImage)GetOrCreate(sprite.Atlas),
+                    new System.Windows.Int32Rect(sprite.X, sprite.Y, sprite.Width, sprite.Height));
 
                 var encoder = new PngBitmapEncoder();
                 var memoryStream = new MemoryStream();

--- a/Mapsui/Mapsui.csproj
+++ b/Mapsui/Mapsui.csproj
@@ -66,7 +66,7 @@
     <Compile Include="Layers\AnimatedFeatures.cs" />
     <Compile Include="Layers\AnimatedPointLayer.cs" />
     <Compile Include="Layers\WritableLayer.cs" />
-    <Compile Include="Styles\Atlas.cs" />
+    <Compile Include="Styles\Sprite.cs" />
     <Compile Include="Styles\StrokeJoin.cs" />
     <Compile Include="Styles\PenStrokeCap.cs" />
     <Compile Include="UI\MapInfo.cs" />

--- a/Mapsui/Styles/BitmapRegistry.cs
+++ b/Mapsui/Styles/BitmapRegistry.cs
@@ -18,11 +18,11 @@ namespace Mapsui.Styles
             if (bitmapData == null) throw new ArgumentException(
                 "The bitmap data that is registered is null. Was the image loaded correctly?");
 
-            if (bitmapData is Atlas atlas)
+            if (bitmapData is Sprite sprite)
             {
-                if (atlas.BitmapId < 0 || !_register.ContainsKey(atlas.BitmapId))
+                if (sprite.Atlas < 0 || !_register.ContainsKey(sprite.Atlas))
                 {
-                    throw new ArgumentException("Atlas has no corresponding atlas bitmap.");
+                    throw new ArgumentException("Sprite has no corresponding atlas bitmap.");
                 }
             }
 

--- a/Mapsui/Styles/Sprite.cs
+++ b/Mapsui/Styles/Sprite.cs
@@ -2,9 +2,9 @@
 
 namespace Mapsui.Styles
 {
-    public class Atlas
+    public class Sprite
     {
-        public int BitmapId { get; }
+        public int Atlas { get; }
         public int X { get; }
         public int Y { get; }
         public int Width { get; }
@@ -12,9 +12,9 @@ namespace Mapsui.Styles
         public float PixelRatio { get; }
         public object Data { get; set; }
 
-        public Atlas(int bitmapId, int x, int y, int width, int height, float pixelRatio)
+        public Sprite(int atlas, int x, int y, int width, int height, float pixelRatio)
         {
-            BitmapId = bitmapId;
+            Atlas = atlas;
             X = x;
             Y = y;
             Width = width;
@@ -22,7 +22,7 @@ namespace Mapsui.Styles
             PixelRatio = pixelRatio;
         }
 
-        public Atlas(int bitmapId, Point p, Size s, float pixelRatio) : this(bitmapId, (int)p.X, (int)p.Y, (int)s.Width, (int)s.Height, pixelRatio)
+        public Sprite(int atlas, Point p, Size s, float pixelRatio) : this(atlas, (int)p.X, (int)p.Y, (int)s.Width, (int)s.Height, pixelRatio)
         {
         }
 

--- a/Samples/Mapsui.Samples.Common/Maps/AtlasSample.cs
+++ b/Samples/Mapsui.Samples.Common/Maps/AtlasSample.cs
@@ -56,7 +56,7 @@ namespace Mapsui.Samples.Common.Maps
 
                 var x = 0 + rnd.Next(0, 12) * 21;
                 var y = 64 + rnd.Next(0, 6) * 21;
-                var bitmapId = BitmapRegistry.Instance.Register(new Atlas(_atlasBitmapId, x, y, 21, 21, 1));
+                var bitmapId = BitmapRegistry.Instance.Register(new Sprite(_atlasBitmapId, x, y, 21, 21, 1));
                 feature.Styles.Add(new SymbolStyle { BitmapId = bitmapId });
 
                 features.Add(feature);

--- a/Tests/Mapsui.Tests.Common/Maps/BitmapSample.cs
+++ b/Tests/Mapsui.Tests.Common/Maps/BitmapSample.cs
@@ -32,11 +32,11 @@ namespace Mapsui.Tests.Common.Maps
 
         public static Features CreateFeatures()
         {
-            var atlasBitmapId = LoadBitmap("Mapsui.Tests.Common.Resources.Images.osm-liberty.png");
-            var atlasAmusementPark15 = new Atlas(atlasBitmapId, 106, 0, 21, 21, 1);
-            var atlasClothingStore15 = new Atlas(atlasBitmapId, 84, 106, 21, 21, 1);
-            var atlasDentist15 = new Atlas(atlasBitmapId, 147, 64, 21, 21, 1);
-            var atlasPedestrianPolygon = new Atlas(atlasBitmapId, 0, 0, 64, 64, 1);
+            var atlas = LoadBitmap("Mapsui.Tests.Common.Resources.Images.osm-liberty.png");
+            var spriteAmusementPark15 = new Sprite(atlas, 106, 0, 21, 21, 1);
+            var spriteClothingStore15 = new Sprite(atlas, 84, 106, 21, 21, 1);
+            var spriteDentist15 = new Sprite(atlas, 147, 64, 21, 21, 1);
+            var spritePedestrianPolygon = new Sprite(atlas, 0, 0, 64, 64, 1);
             var svgTigerBitmapId = LoadBitmap("Mapsui.Tests.Common.Resources.Images.Ghostscript_Tiger.svg");
 
             return new Features
@@ -44,27 +44,27 @@ namespace Mapsui.Tests.Common.Maps
                 new Feature
                 {
                     Geometry = new Point(256, 124),
-                    Styles = new[] {new SymbolStyle {BitmapId = atlasBitmapId}}
+                    Styles = new[] {new SymbolStyle {BitmapId = atlas}}
                 },
                 new Feature
                 {
                     Geometry = new Point(20, 280),
-                    Styles = new[] {new SymbolStyle {BitmapId = BitmapRegistry.Instance.Register(atlasAmusementPark15)} }
+                    Styles = new[] {new SymbolStyle {BitmapId = BitmapRegistry.Instance.Register(spriteAmusementPark15)} }
                 },
                 new Feature
                 {
                     Geometry = new Point(60, 280),
-                    Styles = new[] {new SymbolStyle {BitmapId = BitmapRegistry.Instance.Register(atlasClothingStore15)} }
+                    Styles = new[] {new SymbolStyle {BitmapId = BitmapRegistry.Instance.Register(spriteClothingStore15)} }
                 },
                 new Feature
                 {
                     Geometry = new Point(100, 280),
-                    Styles = new[] {new SymbolStyle {BitmapId = BitmapRegistry.Instance.Register(atlasDentist15)} }
+                    Styles = new[] {new SymbolStyle {BitmapId = BitmapRegistry.Instance.Register(spriteDentist15)} }
                 },
                 new Feature
                 {
                     Geometry = new Point(180, 300),
-                    Styles = new[] {new SymbolStyle {BitmapId = BitmapRegistry.Instance.Register(atlasPedestrianPolygon)} }
+                    Styles = new[] {new SymbolStyle {BitmapId = BitmapRegistry.Instance.Register(spritePedestrianPolygon)} }
                 },
                 new Feature
                 {


### PR DESCRIPTION
It is better to name it Sprite instead of Atlas.

With this it is possible to use small parts (sprite) of a big bitmap (atlas) as bitmaps.